### PR TITLE
Update calllist.js

### DIFF
--- a/lib/calllist.js
+++ b/lib/calllist.js
@@ -163,17 +163,16 @@ const callLists = function () {
             adapter.log.debug('Separating parallel calls for calllist handling');
             call.sort((a,b) => (a.id > b.id) ? 1 : -1);    // was call.reverse(); before
             call.forEach(function(singleCall) { 
-                this.add(singleCall); 
-	            this.addCall(singleCall);                // process all calls of the array
-		        if(singleCall.type > 3) blocker = true;  // but don't update lastId if an earlier started call is still active
+	        this.addCall(singleCall);                // process all calls of the array
+		if(singleCall.type > 3) blocker = true;  // but don't update lastId if an earlier started call is still active
                 if(!blocker && singleCall.id > systemData.native.callLists.lastId) systemData.native.callLists.lastId = singleCall.id;        
             }.bind(this));
         } else {
-	        this.addCall(call);
+	    this.addCall(call);
             if (call.id > this.lastId) this.lastId = call.id;
     	}
     };
-    
+ 
     this.forEach = function (cb) {
         for (const n in TYPES) {
             const list = self[n];

--- a/lib/calllist.js
+++ b/lib/calllist.js
@@ -163,12 +163,12 @@ const callLists = function () {
             adapter.log.debug('Separating parallel calls for calllist handling');
             call.sort((a,b) => (a.id > b.id) ? 1 : -1);    // was call.reverse(); before
             call.forEach(function(singleCall) { 
-	        this.addCall(singleCall);                // process all calls of the array
-		if(singleCall.type > 3) blocker = true;  // but don't update lastId if an earlier started call is still active
-                if(!blocker && singleCall.id > systemData.native.callLists.lastId) systemData.native.callLists.lastId = singleCall.id;        
+                this.addCall(singleCall);                // process all calls of the array
+                if(singleCall.type > 3) blocker = true;  // but don't update lastId if an earlier started call is still active
+                if(!blocker && singleCall.id > systemData.native.callLists.lastId) systemData.native.callLists.lastId = singleCall.id;        
             }.bind(this));
         } else {
-	    this.addCall(call);
+            this.addCall(call);
             if (call.id > this.lastId) this.lastId = call.id;
     	}
     };

--- a/lib/calllist.js
+++ b/lib/calllist.js
@@ -126,36 +126,54 @@ const callLists = function () {
     //     3: 'called'
     // };
 
-    this.addListItem = function (listName, call) {
+    this.addCall2List = function (call, listName) {
+        if (!call) return;
         const list = this[listName];
         if (!list || !list.use) return;
-        call.sym = SYMS[call.type];
-        //call.external = call [externalMapping[~~call.type]];
-        call.external = call [(~~call.type) === 3 ? 'called' : 'caller'];
-        //call.escapedSym = ESCAPED_SYMS[call.type];
-        if (!list.array.find(function (v) { return v.id === call.id; })) list.array.unshift(call);
-        if (list.array.length > list.cfg.maxEntries) list.array.length = list.cfg.maxEntries;
-        if (list.lastId < call.id) {
-            list.lastId = call.id;
-            list.count += 1;
+        if (!list.array.find(function (v) { return v.id === call.id; })) {
+            list.array.unshift(call);
+            if (list.array.length > list.cfg.maxEntries) list.array.length = list.cfg.maxEntries;
+            if (list.lastId < call.id) {
+                list.lastId = call.id;
+                list.count += 1;
+            }
         }
     };
+
+   this.addCall = function(call){
+        call.id = ~~call.id;
+        if(call.type > 3){
+            adapter.log.debug('Ignoring call ID' + call.id + ' because call still active (call.type = ' + call.type + ')');
+        } else {
+            adapter.log.debug('Processing call ID' + call.id + ' (call.type = ' + call.type + ')');
+            call.sym = SYMS[call.type];
+            //call.external = call [externalMapping[~~call.type]];
+            call.external = call [(~~call.type) === 3 ? 'called' : 'caller'];
+            //call.escapedSym = ESCAPED_SYMS[call.type];
+            this.addCall2List(call, NO2NAME[call.type] || call.type);
+            this.addCall2List(call, 'all');
+        }
+    };
 
     this.add = function(call, timestamp) {
         if (!call) return;
         if (timestamp != undefined && timestamp > this.lastTimestamp) this.lastTimestamp = timestamp;
+        let blocker = false;
         if (Array.isArray(call)) {
-            call.reverse();
-            call.forEach(function(v) { this.add(v); }.bind(this));
-            return;
-        }
-        call.id = ~~call.id;
-        const n = NO2NAME[call.type] || call.type;
-        this.addListItem(n, call);
-        this.addListItem('all', call);
-        if (call.id > this.lastId) this.lastId = call.id;
-
+            adapter.log.debug('Separating parallel calls for calllist handling');
+            call.sort((a,b) => (a.id > b.id) ? 1 : -1);    // was call.reverse(); before
+            call.forEach(function(singleCall) { 
+                this.add(singleCall); 
+	            this.addCall(singleCall);                // process all calls of the array
+		        if(singleCall.type > 3) blocker = true;  // but don't update lastId if an earlier started call is still active
+                if(!blocker && singleCall.id > systemData.native.callLists.lastId) systemData.native.callLists.lastId = singleCall.id;        
+            }.bind(this));
+        } else {
+	        this.addCall(call);
+            if (call.id > this.lastId) this.lastId = call.id;
+    	}
     };
+    
     this.forEach = function (cb) {
         for (const n in TYPES) {
             const list = self[n];


### PR DESCRIPTION
Diese Anpassungen beheben eine falsche Bearbeitung der Calllist im Adapter, wenn mehrere Telefonate über die Fritzbox gleichzeitig geführt werden. In diesem Fall werden nämlich bei der Abfrage der Calllist von der Fritzbox neben den beendeten Gesprächen auch noch die aktiven Gespräche (call.type = 9/10/11) zurückgemeldet (siehe issue #31). Da es auch passieren kann, dass das zuerst begonnene Telefonat (niedrigere call.id) erst nach dem danach begonnenen Gespräch (höhere call.id) endet, darf die last.id dann nicht auf die höhere call.id gesetzt werden, da sonst das noch laufende Gespräch nie mehr in die Liste im Adapter eingetragen wird.
